### PR TITLE
Changed License from GNU to GPL-2.0-or-later

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,7 +1,7 @@
 name=u-blox GNSS
 version=0.0.1
 author=Leonardo Bispo
-license=GPL-2.0-or-later
+license=MIT
 maintainer=Leonardo Bispo <l.bispo@live.com>
 sentence=GNSS GPS library without bells and whistles, simply works, low power.
 paragraph=GNSS GPS library without bells and whistles, simply works, low power.

--- a/library.properties
+++ b/library.properties
@@ -1,7 +1,7 @@
 name=u-blox GNSS
 version=0.0.1
 author=Leonardo Bispo
-license=GNU
+license=GPL-2.0-or-later
 maintainer=Leonardo Bispo <l.bispo@live.com>
 sentence=GNSS GPS library without bells and whistles, simply works, low power.
 paragraph=GNSS GPS library without bells and whistles, simply works, low power.


### PR DESCRIPTION
'GNU' is not a valid identifier in library.properties.

I am guessing you might mean `GPL-2.0-or-later`.

There is a full list of valid license codes here:
https://spdx.org/licenses/
